### PR TITLE
Feature/remembrance count info

### DIFF
--- a/src/main/java/kodanect/common/response/CursorPaginationResponse.java
+++ b/src/main/java/kodanect/common/response/CursorPaginationResponse.java
@@ -35,4 +35,7 @@ public class CursorPaginationResponse<T, C> {
 
     /** 다음 페이지가 존재하는지 여부 (true면 다음 요청 가능) */
     private boolean hasNext;
+
+    /** 총 게시물 개수 */
+    private long totalCount;
 }

--- a/src/main/java/kodanect/common/util/CursorFormatter.java
+++ b/src/main/java/kodanect/common/util/CursorFormatter.java
@@ -38,7 +38,7 @@ public class CursorFormatter {
      * @return 다음 커서 정보를 포함한 CursorPaginationResponse
      */
 
-    public static <T extends CursorIdentifiable<C>, C>CursorPaginationResponse<T, C> cursorFormat(List<T> responses, int size) {
+    public static <T extends CursorIdentifiable<C>, C>CursorPaginationResponse<T, C> cursorFormat(List<T> responses, int size, long totalCount) {
         /* 기본 cursor 포맷 */
         boolean hasNext = responses.size() > size;
 
@@ -50,6 +50,7 @@ public class CursorFormatter {
                 .content(content)
                 .nextCursor(nextCursor)
                 .hasNext(hasNext)
+                .totalCount(totalCount)
                 .build();
     }
 

--- a/src/main/java/kodanect/domain/remembrance/dto/MemorialDetailResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/MemorialDetailResponse.java
@@ -102,6 +102,7 @@ public class MemorialDetailResponse {
     private List<MemorialReplyResponse> memorialReplyResponses;
     private Integer replyNextCursor;
     private boolean replyHasNext;
+    private long totalReplyCount;
 
     /* 편지 리스트 */
 
@@ -113,7 +114,7 @@ public class MemorialDetailResponse {
     /** 기증자 상세 조회 객체 생성 메서드 */
     public static MemorialDetailResponse of(
             Memorial memorial, List<MemorialReplyResponse> replies,
-            Integer replyNextCursor, boolean replyHasNext)
+            Integer replyNextCursor, boolean replyHasNext, long totalReplyCount)
     {
         return MemorialDetailResponse.builder()
                 .donateSeq(memorial.getDonateSeq())
@@ -138,6 +139,7 @@ public class MemorialDetailResponse {
                 .memorialReplyResponses(replies)
                 .replyNextCursor(replyNextCursor)
                 .replyHasNext(replyHasNext)
+                .totalReplyCount(totalReplyCount)
                 .build();
     }
 }

--- a/src/main/java/kodanect/domain/remembrance/repository/MemorialReplyRepository.java
+++ b/src/main/java/kodanect/domain/remembrance/repository/MemorialReplyRepository.java
@@ -16,7 +16,7 @@ import java.util.List;
  * <br>
  * 댓글의 생성, 수정, 삭제, 조회 등의 JPA 기반 기능 제공
  *
- * */
+ **/
 public interface MemorialReplyRepository extends JpaRepository<MemorialReply, Integer> {
 
     /**
@@ -58,4 +58,7 @@ public interface MemorialReplyRepository extends JpaRepository<MemorialReply, In
         """
     )
     List<MemorialReplyResponse> findByCursor(@Param("donateSeq") Integer donateSeq, @Param("cursor") Integer cursor, Pageable pageable);
+
+    /** 게시물 번호 기준 총 댓글 수 */
+    long countByDonateSeq(@Param("donateSeq") Integer donateSeq);
 }

--- a/src/main/java/kodanect/domain/remembrance/repository/MemorialRepository.java
+++ b/src/main/java/kodanect/domain/remembrance/repository/MemorialRepository.java
@@ -31,11 +31,10 @@ public interface MemorialRepository extends JpaRepository<Memorial, Integer> {
     @Query(
         value = """
             SELECT new kodanect.domain.remembrance.dto.MemorialResponse
-                    (m.donateSeq, m.donorName, m.anonymityFlag, m.donateDate,m.genderFlag, m.donateAge, COUNT(r))
+                    (m.donateSeq, m.donorName, m.anonymityFlag, m.donateDate,m.genderFlag, m.donateAge,
+                            (SELECT COUNT(r) FROM MemorialReply r WHERE m.donateSeq = r.donateSeq))
             FROM Memorial m
-            LEFT JOIN MemorialReply r ON m.donateSeq = r.donateSeq
             WHERE m.delFlag = 'N' AND (:cursor IS NULL OR m.donateSeq < :cursor)
-            GROUP BY m.donateSeq
             ORDER BY m.donateDate DESC
         """
     )
@@ -47,7 +46,7 @@ public interface MemorialRepository extends JpaRepository<Memorial, Integer> {
      *
      * @param startDate 시작 일
      * @param endDate 종료 일
-     * @param searchWord 검색 문자
+     * @param searchWord 검색 문자 (%검색어%)
      * @param cursor 조회할 댓글 페이지 번호(이 ID보다 작은 번호의 댓글을 조회)
      * @param pageable 최대 결과 개수 등 페이징 정보
      * @return 조건에 맞는 게시글 리스트(최신순)
@@ -55,12 +54,11 @@ public interface MemorialRepository extends JpaRepository<Memorial, Integer> {
     @Query(
         value = """
             SELECT new kodanect.domain.remembrance.dto.MemorialResponse
-                    (m.donateSeq, m.donorName, m.anonymityFlag, m.donateDate, m.genderFlag, m.donateAge, COUNT(r))
+                    (m.donateSeq, m.donorName, m.anonymityFlag, m.donateDate, m.genderFlag, m.donateAge,
+                            (SELECT COUNT(r) FROM MemorialReply r WHERE m.donateSeq = r.donateSeq))
             FROM Memorial m
-            LEFT JOIN MemorialReply r ON m.donateSeq = r.donateSeq
             WHERE m.delFlag = 'N' AND (:cursor IS NULL OR m.donateSeq < :cursor)
                     AND m.donateDate BETWEEN :startDate AND :endDate AND m.donorName LIKE :searchWord
-            GROUP BY m.donateSeq
             ORDER BY m.donateDate DESC
         """
     )

--- a/src/main/java/kodanect/domain/remembrance/service/MemorialReplyService.java
+++ b/src/main/java/kodanect/domain/remembrance/service/MemorialReplyService.java
@@ -75,4 +75,14 @@ public interface MemorialReplyService {
      * */
     CursorReplyPaginationResponse<MemorialReplyResponse, Integer> getMoreReplyList(Integer donateSeq, Integer cursor, int size)
             throws  MemorialNotFoundException;
+
+    /**
+     * 
+     * 기증자 추모관 상세 게시글 댓글 총 갯수 반환 메서드
+     * 
+     * @param donateSeq 상세 게시글 번호
+     * @return 조건에 맞는 댓글 총 갯수
+     * 
+     * */
+    long getTotalReplyCount(Integer donateSeq);
 }

--- a/src/main/java/kodanect/domain/remembrance/service/impl/MemorialReplyServiceImpl.java
+++ b/src/main/java/kodanect/domain/remembrance/service/impl/MemorialReplyServiceImpl.java
@@ -206,7 +206,7 @@ public class MemorialReplyServiceImpl implements MemorialReplyService {
 
         Pageable pageable = PageRequest.of(0, size +1);
 
-        /* 댓글 리스트 모두 조회 */
+        /* 조건에 맞는 댓글 리스트 조회 */
         return memorialReplyRepository.findByCursor(donateSeq, cursor, pageable);
 
     }
@@ -236,6 +236,10 @@ public class MemorialReplyServiceImpl implements MemorialReplyService {
         List<MemorialReplyResponse> memorialReplyResponses = memorialReplyRepository.findByCursor(donateSeq, cursor, pageable);
 
         return CursorFormatter.cursorReplyFormat(memorialReplyResponses, size);
+    }
+
+    public long getTotalReplyCount(Integer donateSeq) {
+        return memorialReplyRepository.countByDonateSeq(donateSeq);
     }
 }
 

--- a/src/main/java/kodanect/domain/remembrance/service/impl/MemorialServiceImpl.java
+++ b/src/main/java/kodanect/domain/remembrance/service/impl/MemorialServiceImpl.java
@@ -136,7 +136,9 @@ public class MemorialServiceImpl implements MemorialService {
 
         List<MemorialResponse> memorialResponses = memorialRepository.findSearchByCursor(cursor, pageable, startDateStr, endDateStr, searchWord);
 
-        return CursorFormatter.cursorFormat(memorialResponses, size);
+        long totalCount = memorialRepository.count();
+
+        return CursorFormatter.cursorFormat(memorialResponses, size, totalCount);
 
     }
 
@@ -157,7 +159,9 @@ public class MemorialServiceImpl implements MemorialService {
 
         List<MemorialResponse> memorialResponses = memorialRepository.findByCursor(cursor, pageable);
 
-        return CursorFormatter.cursorFormat(memorialResponses, size);
+        long totalCount = memorialRepository.count();
+
+        return CursorFormatter.cursorFormat(memorialResponses, size, totalCount);
     }
 
     /**
@@ -183,11 +187,16 @@ public class MemorialServiceImpl implements MemorialService {
         CursorReplyPaginationResponse<MemorialReplyResponse, Integer> cursoredReplies =
                 CursorFormatter.cursorReplyFormat(memorialReplyResponses, DEFAULT_SIZE);
 
+        /* 댓글 총 갯수 조회 */
+        long totalReplyCount = memorialReplyService.getTotalReplyCount(donateSeq);
+
         /* 하늘나라 편지 리스트 조회 예정 */
 
         /* 기증자 상세 조회 */
         return MemorialDetailResponse.of(memorial,
-                cursoredReplies.getContent(), cursoredReplies.getReplyNextCursor(), cursoredReplies.isReplyHasNext());
+                cursoredReplies.getContent(),
+                cursoredReplies.getReplyNextCursor(),
+                cursoredReplies.isReplyHasNext(), totalReplyCount);
     }
 }
 


### PR DESCRIPTION
## 📌 PR 제목
- 간단 요약: feat: 커서 기반 응답 구조 개선 및 게시글/댓글 수 정보 응답에 포함

## 📝 변경사항
- `CursorPaginationResponse`는 totalCount 필드 추가로 확장 대응 가능하게 개선
- 게시글 목록 조회 시 전체 게시글 수(`totalCount`)를 포함하여 프론트에서 더보기 여부 판단 가능
- 상세 조회에서 댓글 수는 최초 응답 시에만 포함되며, 더보기 요청에는 포함되지 않음
- 서비스 단에서 댓글 수 로직을 `MemorialReplyService`로 위임하여 도메인 분리 원칙 유지

## 🙋 기타 코멘트
