### PR TITLE
fix: 댓글 수정 및 커서 직렬화 제거

### DIFF
--- a/src/main/java/kodanect/common/util/CursorIdentifiable.java
+++ b/src/main/java/kodanect/common/util/CursorIdentifiable.java
@@ -1,5 +1,7 @@
 package kodanect.common.util;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  *
  * 커서 기반 페이징을 위한 공용 식별자 인터페이스.
@@ -14,5 +16,6 @@ public interface CursorIdentifiable<T> {
      *
      * @return 커서 ID 반환
      * */
+    @JsonIgnore
     T getCursorId();
 }

--- a/src/main/java/kodanect/domain/remembrance/dto/MemorialDetailResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/MemorialDetailResponse.java
@@ -111,6 +111,11 @@ public class MemorialDetailResponse {
         return FormatUtils.formatDonateDate(this.donateDate);
     }
 
+    /** 2020-12-13T02:11:12 -> 2020-12-13 형식 변경 */
+    public String getWriteTime() {
+        return writeTime.toLocalDate().toString();
+    }
+
     /** 기증자 상세 조회 객체 생성 메서드 */
     public static MemorialDetailResponse of(
             Memorial memorial, List<MemorialReplyResponse> replies,

--- a/src/main/java/kodanect/domain/remembrance/dto/MemorialReplyResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/MemorialReplyResponse.java
@@ -37,5 +37,10 @@ public class MemorialReplyResponse implements CursorIdentifiable<Integer> {
     public Integer getCursorId() {
         return replySeq;
     }
+
+    /** 2020-12-13T02:11:12 -> 2020-12-13 형식 변경 */
+    public String getReplyWriteTime() {
+        return replyWriteTime.toLocalDate().toString();
+    }
 }
 

--- a/src/main/java/kodanect/domain/remembrance/dto/MemorialReplyUpdateRequest.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/MemorialReplyUpdateRequest.java
@@ -11,6 +11,7 @@ import javax.validation.constraints.Pattern;
 import static kodanect.common.exception.config.MessageKeys.REPLY_PASSWORD_EMPTY;
 import static kodanect.common.exception.config.MessageKeys.REPLY_PASSWORD_INVALID;
 import static kodanect.common.exception.config.MessageKeys.REPLY_CONTENTS_EMPTY;
+import static kodanect.common.exception.config.MessageKeys.REPLY_WRITER_EMPTY;
 
 /**
  *
@@ -18,6 +19,7 @@ import static kodanect.common.exception.config.MessageKeys.REPLY_CONTENTS_EMPTY;
  *
  * <p>replyPassword : 댓글 비밀번호</p>
  * <p>replyContents : 댓글 내용</p>
+ * <p>replyWriter : 댓글 작성자 닉네임</p>
  *
  * */
 @Builder
@@ -35,4 +37,8 @@ public class MemorialReplyUpdateRequest {
     /* 댓글 내용 */
     @NotBlank(message = REPLY_CONTENTS_EMPTY, groups = BlankGroup.class)
     private String replyContents;
+
+    /* 댓글 작성자 닉네임 */
+    @NotBlank(message = REPLY_WRITER_EMPTY, groups = BlankGroup.class)
+    private String replyWriter;
 }

--- a/src/main/java/kodanect/domain/remembrance/repository/MemorialReplyRepository.java
+++ b/src/main/java/kodanect/domain/remembrance/repository/MemorialReplyRepository.java
@@ -29,14 +29,14 @@ public interface MemorialReplyRepository extends JpaRepository<MemorialReply, In
      **/
     @Modifying(clearAutomatically = true)
     @Query(
-        value = """
+            value = """
             UPDATE MemorialReply r
-            SET r.replyContents = :contents
+            SET r.replyContents = :contents,
+                r.replyWriter = :writer
             WHERE r.replySeq = :replySeq AND r.delFlag = 'N'
         """
     )
-    void updateReplyContents(@Param("replySeq") Integer replySeq, @Param("contents") String contents);
-
+    void updateReplyContents(@Param("replySeq") Integer replySeq, @Param("contents") String contents, @Param("writer") String writer);
 
     /**
      *
@@ -49,7 +49,7 @@ public interface MemorialReplyRepository extends JpaRepository<MemorialReply, In
      *
      **/
     @Query(
-        value = """
+            value = """
             SELECT new kodanect.domain.remembrance.dto.MemorialReplyResponse
                     (r.replySeq, r.replyWriter, r.replyContents, r.replyWriteTime)
             FROM MemorialReply r

--- a/src/main/java/kodanect/domain/remembrance/service/impl/MemorialReplyServiceImpl.java
+++ b/src/main/java/kodanect/domain/remembrance/service/impl/MemorialReplyServiceImpl.java
@@ -113,9 +113,9 @@ public class MemorialReplyServiceImpl implements MemorialReplyService {
     @Override
     public void updateReply(Integer donateSeq, Integer replySeq, MemorialReplyUpdateRequest memorialReplyUpdateRequest)
             throws  ReplyPasswordMismatchException,
-                    MemorialReplyNotFoundException,
-                    MemorialNotFoundException,
-                    ReplyAlreadyDeleteException
+            MemorialReplyNotFoundException,
+            MemorialNotFoundException,
+            ReplyAlreadyDeleteException
     {
         /* 게시글 댓글 수정 */
         ReentrantReadWriteLock lock = getLock(donateSeq);
@@ -135,7 +135,11 @@ public class MemorialReplyServiceImpl implements MemorialReplyService {
             memorialReply.validateNotDeleted();
 
             /* 댓글 수정 */
-            memorialReplyRepository.updateReplyContents(replySeq, memorialReplyUpdateRequest.getReplyContents());
+            memorialReplyRepository.updateReplyContents(
+                    replySeq,
+                    memorialReplyUpdateRequest.getReplyContents(),
+                    memorialReplyUpdateRequest.getReplyWriter()
+            );
         }
         finally {
             lock.writeLock().unlock();
@@ -154,9 +158,9 @@ public class MemorialReplyServiceImpl implements MemorialReplyService {
     @Override
     public void deleteReply(Integer donateSeq, Integer replySeq, MemorialReplyDeleteRequest memorialReplyDeleteRequest)
             throws  ReplyPasswordMismatchException,
-                    MemorialReplyNotFoundException,
-                    MemorialNotFoundException,
-                    ReplyAlreadyDeleteException
+            MemorialReplyNotFoundException,
+            MemorialNotFoundException,
+            ReplyAlreadyDeleteException
     {
         /* 게시글 댓글 삭제 del_flag = 'Y' 설정 */
         ReentrantReadWriteLock lock = getLock(donateSeq);

--- a/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerTest.java
+++ b/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerTest.java
@@ -176,15 +176,15 @@ class MemorialControllerTest {
                 .andExpect(jsonPath("$.data.proudCount").value(5))
                 .andExpect(jsonPath("$.data.hardCount").value(6))
                 .andExpect(jsonPath("$.data.sadCount").value(7))
-                .andExpect(jsonPath("$.data.writeTime").value("2024-01-01T12:00:00"))
+                .andExpect(jsonPath("$.data.writeTime").value("2024-01-01"))
                 .andExpect(jsonPath("$.data.memorialReplyResponses[0].replySeq").value(1))
                 .andExpect(jsonPath("$.data.memorialReplyResponses[0].replyWriter").value("홍길동"))
                 .andExpect(jsonPath("$.data.memorialReplyResponses[0].replyContents").value("안녕하세요"))
-                .andExpect(jsonPath("$.data.memorialReplyResponses[0].replyWriteTime").value("2024-01-01T12:00:00"))
+                .andExpect(jsonPath("$.data.memorialReplyResponses[0].replyWriteTime").value("2024-01-01"))
                 .andExpect(jsonPath("$.data.memorialReplyResponses[1].replySeq").value(2))
                 .andExpect(jsonPath("$.data.memorialReplyResponses[1].replyWriter").value("김길동"))
                 .andExpect(jsonPath("$.data.memorialReplyResponses[1].replyContents").value("잘가세요"))
-                .andExpect(jsonPath("$.data.memorialReplyResponses[1].replyWriteTime").value("2022-01-01T12:00:00"))
+                .andExpect(jsonPath("$.data.memorialReplyResponses[1].replyWriteTime").value("2022-01-01"))
                 .andExpect(jsonPath("$.data.memorialReplyResponses.length()").value(2));
 
 

--- a/src/test/java/kodanect/domain/remembrance/controller/MemorialReplyControllerExceptionTest.java
+++ b/src/test/java/kodanect/domain/remembrance/controller/MemorialReplyControllerExceptionTest.java
@@ -115,10 +115,10 @@ class MemorialReplyControllerExceptionTest {
     MessageSourceAccessor messageSourceAccessor;
 
     /*
-    *
-    * 댓글 더보기
-    *
-    * */
+     *
+     * 댓글 더보기
+     *
+     * */
 
     @Test
     @DisplayName("댓글 더보기 : 존재하지 않는 게시글을 요청한 경우 - 404")
@@ -170,10 +170,10 @@ class MemorialReplyControllerExceptionTest {
     }
 
     /*
-    *
-    * 댓글 생성
-    *
-    * */
+     *
+     * 댓글 생성
+     *
+     * */
 
     @Test
     @DisplayName("댓글 생성 : 내용이 입력되지 않은 경우 - 400")
@@ -313,10 +313,10 @@ class MemorialReplyControllerExceptionTest {
 
 
     /*
-    *
-    * 댓글 수정
-    *
-    * */
+     *
+     * 댓글 수정
+     *
+     * */
 
     @Test
     @DisplayName("댓글 수정 : 댓글 비밀번호가 입력되지 않은 경우 - 400")
@@ -325,6 +325,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(EMPTY)
                         .build();
@@ -347,6 +348,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -373,6 +375,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -395,6 +398,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -421,6 +425,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(EMPTY)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -442,6 +447,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -464,6 +470,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -490,6 +497,7 @@ class MemorialReplyControllerExceptionTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter(REPLY_WRITER)
                         .replyContents(CONTENTS)
                         .replyPassword(REPLY_PASSWORD)
                         .build();
@@ -510,10 +518,10 @@ class MemorialReplyControllerExceptionTest {
 
 
     /*
-    *
-    * 댓글 삭제
-    *
-    * */
+     *
+     * 댓글 삭제
+     *
+     * */
 
     @Test
     @DisplayName("댓글 삭제 : 비밀번호가 입력되지 않은 경우 - 400")

--- a/src/test/java/kodanect/domain/remembrance/controller/MemorialReplyControllerTest.java
+++ b/src/test/java/kodanect/domain/remembrance/controller/MemorialReplyControllerTest.java
@@ -57,6 +57,7 @@ class MemorialReplyControllerTest {
                 .build();
 
         this.replyUpdateDto = MemorialReplyUpdateRequest.builder()
+                .replyWriter("홍길동")
                 .replyPassword("1234asdf")
                 .replyContents("내용")
                 .build();

--- a/src/test/java/kodanect/domain/remembrance/service/MemorialReplyServiceImplTest.java
+++ b/src/test/java/kodanect/domain/remembrance/service/MemorialReplyServiceImplTest.java
@@ -74,6 +74,7 @@ public class MemorialReplyServiceImplTest {
         MemorialReplyUpdateRequest request =
                 MemorialReplyUpdateRequest
                         .builder()
+                        .replyWriter("홍길동")
                         .replyContents("수정 내용")
                         .replyPassword("1234")
                         .build();
@@ -83,6 +84,7 @@ public class MemorialReplyServiceImplTest {
                         .builder()
                         .donateSeq(donateSeq)
                         .replySeq(replySeq)
+                        .replyWriter("홍길동")
                         .replyContents("안바뀐 내용")
                         .replyPassword("1234")
                         .build();
@@ -92,7 +94,7 @@ public class MemorialReplyServiceImplTest {
 
         memorialReplyService.updateReply(donateSeq, replySeq, request);
 
-        verify(memorialReplyRepository, times(1)).updateReplyContents(replySeq,"수정 내용");
+        verify(memorialReplyRepository, times(1)).updateReplyContents(replySeq,"수정 내용", "홍길동");
     }
 
     @Test
@@ -153,7 +155,7 @@ public class MemorialReplyServiceImplTest {
         assertEquals(1, page.get(0).getReplySeq());
         assertEquals("작성자", page.get(0).getReplyWriter());
         assertEquals("내용입니다",  page.get(0).getReplyContents());
-        assertEquals(LocalDateTime.of(2024,6,1,10,0), page.get(0).getReplyWriteTime());
+        assertEquals("2024-06-01", page.get(0).getReplyWriteTime());
 
         verify(memorialReplyRepository, times(1)).findByCursor(eq(donateSeq), eq(cursor), any(Pageable.class));
     }
@@ -186,7 +188,7 @@ public class MemorialReplyServiceImplTest {
         assertEquals(1, content.get(0).getReplySeq());
         assertEquals("작성자", content.get(0).getReplyWriter());
         assertEquals("내용입니다",  content.get(0).getReplyContents());
-        assertEquals(LocalDateTime.of(2024,6,1,10,0), content.get(0).getReplyWriteTime());
+        assertEquals("2024-06-01", content.get(0).getReplyWriteTime());
 
         verify(memorialReplyRepository, times(1)).findByCursor(eq(donateSeq), eq(cursor), any(Pageable.class));
     }

--- a/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
+++ b/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
@@ -244,7 +244,7 @@ public class MemorialServiceImplTest {
         assertEquals(5, result.getProudCount());
         assertEquals(6, result.getHardCount());
         assertEquals(7, result.getSadCount());
-        assertEquals(LocalDateTime.of(2024, 1, 1, 12, 0), result.getWriteTime());
+        assertEquals("2024-01-01", result.getWriteTime());
         assertEquals(1, result.getMemorialReplyResponses().size());
     }
 


### PR DESCRIPTION
## 📌 PR 제목
- 간단 요약: fix: 댓글 수정 쿼리 통합 및 cursorId 직렬화 제거

## 📝 변경사항
- 댓글 수정 기능 개선: writer와 contents를 동시에 수정 가능하도록 updateReply 쿼리 통합
- CursorIdentifiable 인터페이스에 @JsonIgnore 적용 → getCursorId가 JSON 결과에 노출되지 않도록 처리

## 🙋 기타 코멘트
