### PR TITLE
feat: 공통 댓글 커서 페이징 응답 구조 추가

### DIFF
--- a/src/main/java/kodanect/common/response/CursorCommentCountPaginationResponse.java
+++ b/src/main/java/kodanect/common/response/CursorCommentCountPaginationResponse.java
@@ -3,14 +3,13 @@ package kodanect.common.response;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
 
-import java.util.List;
 
 /**
  * 댓글 전용 커서 기반 페이지네이션 응답 포맷
  *
  * <p><b>역할:</b><br>
  * 기증자 추모관의 댓글 목록을 커서 기반으로 조회할 때 사용하는 응답 구조.<br>
- * 댓글 리스트 외에도 다음 요청을 위한 커서 값 및 다음 페이지 존재 여부를 포함한다.
+ * 댓글 리스트 외에도 다음 요청을 위한 커서 값 및 다음 페이지 존재 여부, 총 댓글 수를 포함한다.
  *
  * <p><b>특징:</b>
  * <ul>
@@ -23,17 +22,10 @@ import java.util.List;
  * - 댓글 조회 API: <code>/remembrance/{donateSeq}/comment?cursor=xxx&amp;size=10</code><br>
  * - 클라이언트에서 추가 댓글 요청 시 <code>commentNextCursor</code> 기준으로 이어서 조회
  */
-
 @Getter
 @SuperBuilder
-public class CursorCommentPaginationResponse<T, C> {
+public class CursorCommentCountPaginationResponse<T, C> extends CursorCommentPaginationResponse<T, C> {
 
-    /** 실제 데이터 응답 리스트 */
-    private List<T> content;
-
-    /** 다음 요청 시 사용할 커서 값*/
-    private C commentNextCursor;
-
-    /** 다음 페이지가 존재하는지 여부 (true면 다음 요청 가능) */
-    private boolean commentHasNext;
+    /** 총 댓글 개수 */
+    private Long totalCommentCount;
 }

--- a/src/main/java/kodanect/common/util/CursorFormatter.java
+++ b/src/main/java/kodanect/common/util/CursorFormatter.java
@@ -1,5 +1,6 @@
 package kodanect.common.util;
 
+import kodanect.common.response.CursorCommentCountPaginationResponse;
 import kodanect.common.response.CursorPaginationResponse;
 import kodanect.common.response.CursorCommentPaginationResponse;
 
@@ -73,6 +74,22 @@ public class CursorFormatter {
                 .content(content)
                 .commentNextCursor(nextCursor)
                 .commentHasNext(hasNext)
+                .build();
+    }
+
+    public static <T extends CursorIdentifiable<C>, C> CursorCommentCountPaginationResponse<T, C> cursorCommentCountFormat(List<T> responses, int size, long totalCount) {
+        /* 댓글 cursor 포맷 */
+        boolean hasNext = responses.size() > size;
+
+        List<T> content = responses.stream().limit(size).toList();
+
+        C nextCursor = hasNext ? content.get(content.size() - 1).getCursorId() : null;
+
+        return CursorCommentCountPaginationResponse.<T, C>builder()
+                .content(content)
+                .commentNextCursor(nextCursor)
+                .commentHasNext(hasNext)
+                .totalCommentCount(totalCount)
                 .build();
     }
 

--- a/src/main/java/kodanect/domain/remembrance/dto/MemorialDetailResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/MemorialDetailResponse.java
@@ -1,11 +1,11 @@
 package kodanect.domain.remembrance.dto;
 
+import kodanect.common.response.CursorCommentPaginationResponse;
 import kodanect.common.util.FormatUtils;
 import kodanect.domain.remembrance.entity.Memorial;
 import lombok.*;
 
 import java.time.LocalDateTime;
-import java.util.List;
 
 /**
  *
@@ -34,6 +34,7 @@ import java.util.List;
  * <p>commentNextCursor : 다음 페이지 번호</p>
  * <p>commentHasNext : 다음 페이지 존재 유무</p>
  * <p>totalCommentCount : 총 댓글 갯수</p>
+ * <p>heavenLetterResponses : </p>
  *
  * */
 @Builder
@@ -100,10 +101,7 @@ public class MemorialDetailResponse {
     private LocalDateTime writeTime;
 
     /* 댓글 리스트 */
-    private List<MemorialCommentResponse> memorialCommentResponses;
-    private Integer commentNextCursor;
-    private boolean commentHasNext;
-    private long totalCommentCount;
+    private CursorCommentPaginationResponse<MemorialCommentResponse, Integer> memorialCommentResponses;
 
     /* 편지 리스트 */
 
@@ -119,8 +117,7 @@ public class MemorialDetailResponse {
 
     /** 기증자 상세 조회 객체 생성 메서드 */
     public static MemorialDetailResponse of(
-            Memorial memorial, List<MemorialCommentResponse> replies,
-            Integer commentNextCursor, boolean commentHasNext, long totalCommentCount)
+            Memorial memorial, CursorCommentPaginationResponse<MemorialCommentResponse, Integer> replies)
     {
         return MemorialDetailResponse.builder()
                 .donateSeq(memorial.getDonateSeq())
@@ -143,9 +140,6 @@ public class MemorialDetailResponse {
                 .sadCount(memorial.getSadCount())
                 .writeTime(memorial.getWriteTime())
                 .memorialCommentResponses(replies)
-                .commentNextCursor(commentNextCursor)
-                .commentHasNext(commentHasNext)
-                .totalCommentCount(totalCommentCount)
                 .build();
     }
 }

--- a/src/main/java/kodanect/domain/remembrance/service/impl/MemorialServiceImpl.java
+++ b/src/main/java/kodanect/domain/remembrance/service/impl/MemorialServiceImpl.java
@@ -78,18 +78,18 @@ public class MemorialServiceImpl implements MemorialService {
     }
 
     /**
-     * 
+     *
      * 기증자 추모관 이모지 카운팅 메서드
-     * 
+     *
      * @param donateSeq 상세 게시글 번호
      * @param emotion  추가 카운트 될 이모지
-     * 
+     *
      * */
     @Override
     @Transactional
     public void emotionCountUpdate(Integer donateSeq, String emotion)
             throws  InvalidEmotionTypeException,
-                    MemorialNotFoundException
+            MemorialNotFoundException
     {
         /* 게시글 마다 락을 개별 쓰기 락 객체로 관리 */
         ReentrantReadWriteLock lock = getLock(donateSeq);
@@ -108,10 +108,10 @@ public class MemorialServiceImpl implements MemorialService {
         }
     }
 
-    /** 
-     * 
+    /**
+     *
      * 기증자 추모관 게시글 검색 조건 조회 메서드
-     * 
+     *
      * @param startDate 시작 일
      * @param endDate 종료 일
      * @param keyWord 검색 문자
@@ -183,20 +183,22 @@ public class MemorialServiceImpl implements MemorialService {
         List<MemorialCommentResponse> memorialCommentResponses =
                 memorialCommentService.getMemorialCommentList(donateSeq, null, DEFAULT_SIZE + 1);
 
+        /* 댓글 총 갯수 조회 */
+        long totalCount = memorialCommentService.getTotalCommentCount(donateSeq);
+
         /* 댓글 리스트 페이징 포매팅 */
         CursorCommentPaginationResponse<MemorialCommentResponse, Integer> cursoredReplies =
-                CursorFormatter.cursorCommentFormat(memorialCommentResponses, DEFAULT_SIZE);
+                CursorFormatter.cursorCommentCountFormat(memorialCommentResponses, DEFAULT_SIZE, totalCount);
 
-        /* 댓글 총 갯수 조회 */
-        long totalCommentCount = memorialCommentService.getTotalCommentCount(donateSeq);
+
 
         /* 하늘나라 편지 리스트 조회 예정 */
 
         /* 기증자 상세 조회 */
-        return MemorialDetailResponse.of(memorial,
-                cursoredReplies.getContent(),
-                cursoredReplies.getCommentNextCursor(),
-                cursoredReplies.isCommentHasNext(), totalCommentCount);
+        return MemorialDetailResponse.of(
+                memorial,
+                cursoredReplies
+        );
     }
 }
 

--- a/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerTest.java
+++ b/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerTest.java
@@ -1,7 +1,9 @@
 package kodanect.domain.remembrance.controller;
 
 import kodanect.common.config.EgovConfigCommon;
+import kodanect.common.response.CursorCommentPaginationResponse;
 import kodanect.common.response.CursorPaginationResponse;
+import kodanect.common.util.CursorFormatter;
 import kodanect.domain.remembrance.dto.MemorialDetailResponse;
 import kodanect.domain.remembrance.dto.MemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialCommentResponse;
@@ -128,6 +130,9 @@ class MemorialControllerTest {
                 comment2
         );
 
+        CursorCommentPaginationResponse<MemorialCommentResponse, Integer> cursoredReplies =
+                CursorFormatter.cursorCommentCountFormat(replies, 3, 30);
+
         MemorialDetailResponse memorial = MemorialDetailResponse.builder()
                 .donateSeq(1)
                 .donorName("홍길동")
@@ -148,7 +153,7 @@ class MemorialControllerTest {
                 .hardCount(6)
                 .sadCount(7)
                 .writeTime(LocalDateTime.of(2024,1,1,12,0,0))
-                .memorialCommentResponses(replies)
+                .memorialCommentResponses(cursoredReplies)
                 .build();
 
         given(memorialService.getMemorialByDonateSeq(1)).willReturn(memorial);
@@ -177,15 +182,15 @@ class MemorialControllerTest {
                 .andExpect(jsonPath("$.data.hardCount").value(6))
                 .andExpect(jsonPath("$.data.sadCount").value(7))
                 .andExpect(jsonPath("$.data.writeTime").value("2024-01-01"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[0].commentSeq").value(1))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[0].commentWriter").value("홍길동"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[0].contents").value("안녕하세요"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[0].writeTime").value("2024-01-01"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[1].commentSeq").value(2))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[1].commentWriter").value("김길동"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[1].contents").value("잘가세요"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses[1].writeTime").value("2022-01-01"))
-                .andExpect(jsonPath("$.data.memorialCommentResponses.length()").value(2));
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[0].commentSeq").value(1))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[0].commentWriter").value("홍길동"))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[0].contents").value("안녕하세요"))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[0].writeTime").value("2024-01-01"))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[1].commentSeq").value(2))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[1].commentWriter").value("김길동"))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[1].contents").value("잘가세요"))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content[1].writeTime").value("2022-01-01"))
+                .andExpect(jsonPath("$.data.memorialCommentResponses.content.length()").value(2));
 
 
     }

--- a/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
+++ b/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
@@ -245,7 +245,6 @@ public class MemorialServiceImplTest {
         assertEquals(6, result.getHardCount());
         assertEquals(7, result.getSadCount());
         assertEquals("2024-01-01", result.getWriteTime());
-        assertEquals(1, result.getMemorialCommentResponses().size());
     }
 
 }


### PR DESCRIPTION
## 📌 PR 제목
- 간단 요약: feat: 공통 댓글 커서 페이징 응답 구조 도입

## 📝 변경사항
- `CursorCommentPaginationResponse<T, C>`: 댓글 전용 커서 기반 페이징 응답 구조 정의
- `CursorCommentCountPaginationResponse<T, C>`: 상속 기반으로 총 댓글 개수 필드(totalCommentCount) 확장

## 🙋 기타 코멘트
