### PR TITLE
feat: Heaven 팝업용 게시물 검색 조회 기능 추가

### DIFF
--- a/src/main/java/kodanect/domain/remembrance/controller/MemorialController.java
+++ b/src/main/java/kodanect/domain/remembrance/controller/MemorialController.java
@@ -2,12 +2,14 @@ package kodanect.domain.remembrance.controller;
 
 import kodanect.common.response.ApiResponse;
 import kodanect.common.response.CursorPaginationResponse;
+import kodanect.domain.remembrance.dto.HeavenMemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialDetailResponse;
 import kodanect.domain.remembrance.dto.MemorialResponse;
 import kodanect.domain.remembrance.dto.common.MemorialNextCursor;
 import kodanect.domain.remembrance.exception.*;
 import kodanect.domain.remembrance.service.MemorialService;
 import org.springframework.context.support.MessageSourceAccessor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -97,7 +99,7 @@ public class MemorialController {
             @RequestParam(defaultValue = "") String keyWord,
             @RequestParam(defaultValue = "20") int size,
             @ModelAttribute MemorialNextCursor nextCursor)
-            throws InvalidPaginationException,
+            throws  InvalidPaginationException,
                     MissingSearchDateParameterException,
                     InvalidSearchDateFormatException,
                     InvalidSearchDateRangeException
@@ -112,6 +114,42 @@ public class MemorialController {
 
         String successMessage = messageSourceAccessor.getMessage("board.search.read.success", new Object[] {});
         CursorPaginationResponse<MemorialResponse, MemorialNextCursor> memorialResponses = memorialService.getSearchMemorialList(startDate, endDate, keyWord, nextCursor, size);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, successMessage, memorialResponses));
+    }
+
+    /**
+     * 하늘나라 편지 팝업 조회 ->
+     * 기증자 추모관 게시글 검색 조회 메서드
+     *
+     * @param startDate 시작 일
+     * @param endDate 종료 일
+     * @param keyWord 검색할 문자
+     * @param page 페이지 번호
+     * @param size 페이지 사이즈
+     *
+     * */
+    @GetMapping("/heaven")
+    public ResponseEntity<ApiResponse<Page<HeavenMemorialResponse>>> getMemorialByHeaven(
+            @RequestParam(defaultValue = "1900-01-01") String startDate,
+            @RequestParam(defaultValue = "2100-12-31") String endDate,
+            @RequestParam(defaultValue = "") String keyWord,
+            @RequestParam(defaultValue = "1") Integer page,
+            @RequestParam(defaultValue = "20") int size)
+            throws  InvalidPaginationException,
+                    MissingSearchDateParameterException,
+                    InvalidSearchDateFormatException,
+                    InvalidSearchDateRangeException
+    {
+        /* 하늘나라 편지 팝업 추모자 검색 조회 */
+
+        /* 날짜 조건 검증 */
+        validateSearchDates(startDate, endDate);
+
+        /* 페이징 요청 검증 */
+        validatePagination(page, size);
+
+        String successMessage = messageSourceAccessor.getMessage("board.search.read.success", new Object[] {});
+        Page<HeavenMemorialResponse> memorialResponses = memorialService.getSearchHeavenMemorialList(startDate, endDate, keyWord, page, size);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK, successMessage, memorialResponses));
     }
 

--- a/src/main/java/kodanect/domain/remembrance/controller/MemorialController.java
+++ b/src/main/java/kodanect/domain/remembrance/controller/MemorialController.java
@@ -134,7 +134,7 @@ public class MemorialController {
             @RequestParam(defaultValue = "2100-12-31") String endDate,
             @RequestParam(defaultValue = "") String keyWord,
             @RequestParam(defaultValue = "1") Integer page,
-            @RequestParam(defaultValue = "20") int size)
+            @RequestParam(defaultValue = "10") int size)
             throws  InvalidPaginationException,
                     MissingSearchDateParameterException,
                     InvalidSearchDateFormatException,

--- a/src/main/java/kodanect/domain/remembrance/dto/HeavenMemorialResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/HeavenMemorialResponse.java
@@ -1,5 +1,16 @@
 package kodanect.domain.remembrance.dto;
 
+/**
+ *
+ * 기증자 추모관 게시글 응답 dto
+ *
+ * <p>donateSeq : 게시글 번호</p>
+ * <p>donorName : 기증자 명</p>
+ * <p>donateDate : 기증 일시</p>
+ * <p>genderFlag : 기증자 성별</p>
+ * <p>donateAge : 기증자 나이</p>
+ *
+ * */
 public interface HeavenMemorialResponse {
 
     /* 기증자 일련번호 */

--- a/src/main/java/kodanect/domain/remembrance/dto/HeavenMemorialResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/HeavenMemorialResponse.java
@@ -1,0 +1,19 @@
+package kodanect.domain.remembrance.dto;
+
+public interface HeavenMemorialResponse {
+
+    /* 기증자 일련번호 */
+    Integer getDonateSeq();
+
+    /* 기증자 명 */
+    String getDonorName();
+
+    /* 기증자 기증 일시 20120101 */
+    String getDonateDate();
+
+    /* 기증자 성별 */
+    String getGenderFlag();
+
+    /* 기증자 나이 */
+    Integer getDonateAge();
+}

--- a/src/main/java/kodanect/domain/remembrance/dto/MemorialResponse.java
+++ b/src/main/java/kodanect/domain/remembrance/dto/MemorialResponse.java
@@ -9,11 +9,11 @@ import kodanect.domain.remembrance.dto.common.MemorialNextCursor;
  *
  * <p>donateSeq : 게시글 번호</p>
  * <p>donorName : 기증자 명</p>
- * <p>anonymityFlag : 익명 여부 Y, N</p>
  * <p>donateDate : 기증 일시</p>
  * <p>genderFlag : 기증자 성별</p>
  * <p>donateAge : 기증자 나이</p>
  * <p>commentCount : 댓글 개수</p>
+ * <p>letterCount : 편지 개수</p>
  *
  * */
 public interface MemorialResponse extends CursorIdentifiable<MemorialNextCursor> {

--- a/src/main/java/kodanect/domain/remembrance/repository/MemorialRepository.java
+++ b/src/main/java/kodanect/domain/remembrance/repository/MemorialRepository.java
@@ -1,7 +1,9 @@
 package kodanect.domain.remembrance.repository;
 
+import kodanect.domain.remembrance.dto.HeavenMemorialResponse;
 import kodanect.domain.remembrance.entity.Memorial;
 import kodanect.domain.remembrance.dto.MemorialResponse;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,6 +20,37 @@ import java.util.List;
  *
  * */
 public interface MemorialRepository extends JpaRepository<Memorial, Integer> {
+
+
+    @Query(
+            value = """
+                SELECT m.donate_seq AS donateSeq,
+                       CASE
+                           WHEN m.anonymity_flag = 'Y'
+                           THEN CONCAT(LEFT(m.donor_name, 1), REPEAT('*', CHAR_LENGTH(m.donor_name) - 1))
+                           ELSE m.donor_name
+                       END AS donorName,
+                       DATE_FORMAT(m.donate_date, '%Y-%m-%d') AS donateDate,
+                       m.gender_flag AS genderFlag,
+                       m.donate_age AS donateAge
+                FROM tb25_400_memorial m
+                WHERE m.del_flag = 'N'
+                        AND m.donate_date BETWEEN :startDate AND :endDate
+                        AND m.donor_name LIKE :keyWord
+                ORDER BY m.donate_date DESC
+        """, countQuery = """
+                SELECT COUNT(*)
+                FROM tb25_400_memorial m
+                WHERE m.del_flag = 'N'
+                        AND m.donate_date BETWEEN :startDate AND :endDate
+                        AND m.donor_name LIKE :keyWord
+        """, nativeQuery = true
+    )
+    Page<HeavenMemorialResponse> findSearchByPage(
+            Pageable pageable,
+            @Param("startDate") String startDate,
+            @Param("endDate") String endDate,
+            @Param("keyWord") String keyWord);
 
     /**
      *

--- a/src/main/java/kodanect/domain/remembrance/repository/MemorialRepository.java
+++ b/src/main/java/kodanect/domain/remembrance/repository/MemorialRepository.java
@@ -22,6 +22,15 @@ import java.util.List;
 public interface MemorialRepository extends JpaRepository<Memorial, Integer> {
 
 
+    /**
+     *
+     * 기증자 추모관 게시글 리스트 날짜 + 문자 조건 페이징 조회
+     *
+     * @param startDate 시작 일
+     * @param endDate 종료 일
+     * @param keyWord 검색 문자 (%검색어%)
+     * @return 조건에 맞는 게시글 순서 리스트(최신순)
+     * */
     @Query(
             value = """
                 SELECT m.donate_seq AS donateSeq,

--- a/src/main/java/kodanect/domain/remembrance/service/MemorialService.java
+++ b/src/main/java/kodanect/domain/remembrance/service/MemorialService.java
@@ -1,10 +1,12 @@
 package kodanect.domain.remembrance.service;
 
 import kodanect.common.response.CursorPaginationResponse;
+import kodanect.domain.remembrance.dto.HeavenMemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialDetailResponse;
 import kodanect.domain.remembrance.dto.MemorialResponse;
 import kodanect.domain.remembrance.dto.common.MemorialNextCursor;
 import kodanect.domain.remembrance.exception.*;
+import org.springframework.data.domain.Page;
 
 public interface MemorialService {
     /**
@@ -31,6 +33,18 @@ public interface MemorialService {
      *
      * */
     CursorPaginationResponse<MemorialResponse, MemorialNextCursor> getSearchMemorialList(String startDate, String endDate, String keyWord, MemorialNextCursor cursor, int size);
+    /**
+     * 하늘나라 편지 팝업 조회 ->
+     * 기증자 추모관 게시글 검색 조회 메서드
+     *
+     * @param startDate 시작 일
+     * @param endDate 종료 일
+     * @param keyWord 검색할 문자
+     * @param page 페이지 번호
+     * @param size 페이지 사이즈
+     *
+     * */
+    Page<HeavenMemorialResponse> getSearchHeavenMemorialList(String startDate, String endDate, String keyWord, Integer page, int size);
     /**
      *
      * 기증자 추모관 게시글 조회 메서드

--- a/src/main/java/kodanect/domain/remembrance/service/impl/MemorialServiceImpl.java
+++ b/src/main/java/kodanect/domain/remembrance/service/impl/MemorialServiceImpl.java
@@ -16,6 +16,7 @@ import kodanect.domain.remembrance.service.MemorialCommentService;
 import kodanect.domain.remembrance.service.MemorialService;
 import kodanect.common.util.EmotionType;
 import kodanect.common.util.MemorialFinder;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -154,6 +155,24 @@ public class MemorialServiceImpl implements MemorialService {
 
         return CursorFormatter.cursorFormat(memorialResponses, size, totalCount);
 
+    }
+
+    @Override
+    public Page<HeavenMemorialResponse> getSearchHeavenMemorialList(
+            String startDate, String endDate, String keyWord, Integer page, int size)
+    {
+
+        /* 검색 문자 포매팅 */
+        keyWord = formatSearchWord(keyWord);
+
+        /* 날짜 포매팅 */
+        String startDateStr = formatDate(startDate);
+        String endDateStr = formatDate(endDate);
+
+        /* 페이지 포매팅 */
+        Pageable pageable = Pageable.ofSize(size).withPage(page - 1);
+
+        return memorialRepository.findSearchByPage(pageable, startDateStr, endDateStr, keyWord);
     }
 
     /**

--- a/src/test/java/kodanect/domain/remembrance/TestHeavenMemorialResponse.java
+++ b/src/test/java/kodanect/domain/remembrance/TestHeavenMemorialResponse.java
@@ -1,0 +1,32 @@
+package kodanect.domain.remembrance;
+
+import kodanect.common.util.FormatUtils;
+import kodanect.domain.remembrance.dto.HeavenMemorialResponse;
+
+public class TestHeavenMemorialResponse implements HeavenMemorialResponse {
+
+    private final Integer donateSeq;
+    private final String donorName;
+    private final String donateDate;
+    private final String genderFlag;
+    private final Integer donateAge;
+
+    public TestHeavenMemorialResponse(Integer donateSeq, String donorName, String donateDate,
+                                String genderFlag, Integer donateAge) {
+        this.donateSeq = donateSeq;
+        this.donorName = donorName;
+        this.donateDate = donateDate;
+        this.genderFlag = genderFlag;
+        this.donateAge = donateAge;
+    }
+
+    @Override public Integer getDonateSeq() { return donateSeq; }
+    @Override public String getDonorName() { return donorName; }
+    @Override public String getGenderFlag() { return genderFlag; }
+    @Override public Integer getDonateAge() { return donateAge; }
+
+    @Override
+    public String getDonateDate() {
+        return FormatUtils.formatDonateDate(donateDate); // "20230101" → "2023-01-01"
+    }
+}

--- a/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerExceptionTest.java
+++ b/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerExceptionTest.java
@@ -66,6 +66,8 @@ class MemorialControllerExceptionTest {
 
     private static final String INVALID_PAGINATION_MESSAGE =
             "요청한 페이지 범위가 잘못되었습니다. (cursor: -1, size: -1, date: null)";
+    private static final String INVALID_PAGINATION_PAGE_MESSAGE =
+            "요청한 페이지 범위가 잘못되었습니다. (cursor: null, size: -1, date: null)";
     private static final String MEMORIAL_NOT_FOUND_MESSAGE =
             "해당 추모글을 찾을 수 없습니다. (donateSeq: 2,147,483,647)";
     private static final String DONATE_INVALID_MESSAGE =
@@ -141,10 +143,10 @@ class MemorialControllerExceptionTest {
     }
 
     /*
-    *
-    * 추모관 게시글 검색 조회
-    *
-    * */
+     *
+     * 추모관 게시글 검색 조회
+     *
+     * */
 
     @Test
     @DisplayName("추모관 게시글 리스트 검색 조회 : 유효하지 않은 페이징 범위를 요청한 경우 - 400")
@@ -189,6 +191,63 @@ class MemorialControllerExceptionTest {
                         .param("endDate", START_DATE)
                         .param("searchWord", EMPTY)
                         .param("cursor", String.valueOf(CURSOR))
+                        .param("size", String.valueOf(SIZE)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.message").value(SEARCH_DATE_RANGE_INVALID_MESSAGE));
+    }
+
+    /*
+     *
+     * 추모관 게시글 하늘나라 팝업 검색 조회
+     *
+     * */
+
+    @Test
+    @DisplayName("추모관 게시글 하늘나라 팝업 리스트 검색 조회 : 유효하지 않은 페이징 범위를 요청한 경우 - 400")
+    void getSearchHeavenMemorialListInvalidPaginationRangeException() throws Exception {
+
+        mockMvc.perform(get("/remembrance/search")
+                        .param("startDate", START_DATE)
+                        .param("endDate", END_DATE)
+                        .param("searchWord", EMPTY)
+                        .param("page", String.valueOf(INVALID_CURSOR))
+                        .param("size", String.valueOf(INVALID_SIZE)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.message").value(INVALID_PAGINATION_PAGE_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("추모관 게시글 하늘나라 팝업 리스트 검색 조회 : 날짜 검색 파라미터가 누락된 경우 - 400")
+    void getSearchHeavenMemorialListInvalidSearchDateException() throws Exception {
+
+        mockMvc.perform(get("/remembrance/search")
+                        .param("startDate", "invalid")
+                        .param("endDate", "invalid")
+                        .param("searchWord", EMPTY)
+                        .param("page", String.valueOf(CURSOR))
+                        .param("size", String.valueOf(SIZE)))
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.code").value(BAD_REQUEST))
+                .andExpect(jsonPath("$.message").value(SEARCH_DATE_INVALID_MESSAGE));
+    }
+
+    @Test
+    @DisplayName("추모관 게시글 하늘나라 팝업 리스트 검색 조회 : 유효하지 않은 날짜 범위를 요청한 경우 - 400")
+    void getSearchHeavenMemorialListInvalidSearchDateRangeException() throws Exception {
+
+        mockMvc.perform(get("/remembrance/search")
+                        .param("startDate", END_DATE)
+                        .param("endDate", START_DATE)
+                        .param("searchWord", EMPTY)
+                        .param("page", String.valueOf(CURSOR))
                         .param("size", String.valueOf(SIZE)))
                 .andDo(print())
                 .andExpect(status().isBadRequest())

--- a/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerTest.java
+++ b/src/test/java/kodanect/domain/remembrance/controller/MemorialControllerTest.java
@@ -4,7 +4,9 @@ import kodanect.common.config.EgovConfigCommon;
 import kodanect.common.response.CursorCommentPaginationResponse;
 import kodanect.common.response.CursorPaginationResponse;
 import kodanect.common.util.CursorFormatter;
+import kodanect.domain.remembrance.TestHeavenMemorialResponse;
 import kodanect.domain.remembrance.TestMemorialResponse;
+import kodanect.domain.remembrance.dto.HeavenMemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialDetailResponse;
 import kodanect.domain.remembrance.dto.MemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialCommentResponse;
@@ -18,6 +20,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
@@ -50,6 +55,7 @@ class MemorialControllerTest {
     @Captor ArgumentCaptor<String> startDateCaptor;
     @Captor ArgumentCaptor<String> endDateCaptor;
     @Captor ArgumentCaptor<MemorialNextCursor> cursorCaptor;
+    @Captor ArgumentCaptor<Integer> pageCaptor;
     @Captor ArgumentCaptor<Integer> sizeCaptor;
 
     @Test
@@ -246,6 +252,56 @@ class MemorialControllerTest {
 
         MemorialNextCursor cursor = cursorCaptor.getValue();
         assertThat(cursor).isNotNull();
+    }
+
+    @Test
+    @DisplayName("추모관 하늘나라 팝업 검색 조회")
+    void 추모관_하늘나라_팝업_검색_조회() throws Exception {
+        /* 기증자 추모관 게시글 하늘나라 팝업 검색 리스트 조회 */
+        /* 검색 조건이 없는 경우 */
+        /* 컨트롤러 테스트는 필터링 로직이 반영되지 않음 */
+
+        List<HeavenMemorialResponse> content = List.of(
+                new TestHeavenMemorialResponse(1, "홍길동", "20200101", "M", 10),
+                new TestHeavenMemorialResponse(2, "김길동",  "20200102", "F", 20),
+                new TestHeavenMemorialResponse(3, "나길동",  "20220103", "M", 30)
+        );
+
+        Page<HeavenMemorialResponse> page = new PageImpl<>(
+                content,
+                PageRequest.of(0,20),
+                100
+        );
+
+        given(memorialService.getSearchHeavenMemorialList(anyString(), anyString(), anyString(), anyInt(), anyInt()))
+                .willReturn(page);
+
+        mockMvc.perform(get("/remembrance/heaven")
+                        .param("startDate", "1900-01-01")
+                        .param("endDate", "2100-12-31")
+                        .param("keyWord", "")
+                        .param("page", "1")
+                        .param("size", "20"))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("게시글 검색 조회 성공"))
+                .andExpect(jsonPath("$.data.content.length()").value(3));
+
+        verify(memorialService).getSearchHeavenMemorialList(
+                startDateCaptor.capture(),
+                endDateCaptor.capture(),
+                searchWordCaptor.capture(),
+                pageCaptor.capture(),
+                sizeCaptor.capture()
+        );
+
+        assertThat(startDateCaptor.getValue()).isEqualTo("1900-01-01");
+        assertThat(endDateCaptor.getValue()).isEqualTo("2100-12-31");
+        assertThat(searchWordCaptor.getValue()).isEmpty();
+        assertThat(sizeCaptor.getValue()).isEqualTo(20);
+        assertThat(pageCaptor.getValue()).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
+++ b/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
@@ -4,7 +4,9 @@ import kodanect.common.response.CursorPaginationResponse;
 import kodanect.common.util.MemorialFinder;
 import kodanect.domain.heaven.dto.response.MemorialHeavenResponse;
 import kodanect.domain.heaven.service.HeavenService;
+import kodanect.domain.remembrance.TestHeavenMemorialResponse;
 import kodanect.domain.remembrance.TestMemorialResponse;
+import kodanect.domain.remembrance.dto.HeavenMemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialDetailResponse;
 import kodanect.domain.remembrance.dto.MemorialResponse;
 import kodanect.domain.remembrance.dto.MemorialCommentResponse;
@@ -17,6 +19,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
@@ -154,6 +159,48 @@ public class MemorialServiceImplTest {
         assertEquals("M", item.getGenderFlag());
         assertEquals(Integer.valueOf(40), item.getDonateAge());
         assertEquals(5, item.getCommentCount());
+    }
+
+    @Test
+    @DisplayName("추모관 게시글 하늘나라 팝업 검색 조회")
+    public void 추모관_게시글_하늘나라_팝업_검색_조회() throws Exception {
+        /* getSearchMemorialList */
+        Integer page = 1;
+        int size = 20;
+        String startDate = "2023-01-01";
+        String endDate = "2024-01-01";
+        String searchWord = "홍길동";
+
+        List<HeavenMemorialResponse> content = List.of(
+                new TestHeavenMemorialResponse(2, "홍길동", "2023-01-02", "M", 40),
+                new TestHeavenMemorialResponse(3, "홍길동", "2023-01-03", "M", 42)
+        );
+
+        Page<HeavenMemorialResponse> result = new PageImpl<>(
+                content,
+                PageRequest.of(0,20),
+                100
+        );
+
+        when(memorialRepository.findSearchByPage(
+                any(Pageable.class),
+                eq("20230101"),       // startDateStr
+                eq("20240101"),       // endDateStr
+                eq("%홍길동%")       // keyWord
+        )).thenReturn(result);
+
+        Page<HeavenMemorialResponse> response = memorialService.getSearchHeavenMemorialList(
+                startDate, endDate, searchWord, page, size
+                );
+
+        assertNotNull(result);
+        assertEquals(2, result.getContent().size());
+
+        HeavenMemorialResponse item = response.getContent().get(0);
+        assertEquals("홍길동", item.getDonorName());
+        assertEquals("2023-01-02", item.getDonateDate());
+        assertEquals("M", item.getGenderFlag());
+        assertEquals(Integer.valueOf(40), item.getDonateAge());
     }
 
 

--- a/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
+++ b/src/test/java/kodanect/domain/remembrance/service/MemorialServiceImplTest.java
@@ -53,7 +53,7 @@ public class MemorialServiceImplTest {
 
     @Test
     @DisplayName("추모관 이모지 카운팅")
-    public void 추모관_이모지_카운팅() throws Exception {
+    public void 추모관_이모지_카운팅() {
         /* emotionCountUpdate */
 
         Integer donateSeq = 1;
@@ -121,7 +121,7 @@ public class MemorialServiceImplTest {
 
     @Test
     @DisplayName("추모관 게시글 검색 조회")
-    public void 추모관_게시글_검색_조회() throws Exception {
+    public void 추모관_게시글_검색_조회() {
         /* getSearchMemorialList */
         MemorialNextCursor nextCursor = new MemorialNextCursor(null, null);
         int size = 20;
@@ -163,7 +163,7 @@ public class MemorialServiceImplTest {
 
     @Test
     @DisplayName("추모관 게시글 하늘나라 팝업 검색 조회")
-    public void 추모관_게시글_하늘나라_팝업_검색_조회() throws Exception {
+    public void 추모관_게시글_하늘나라_팝업_검색_조회() {
         /* getSearchMemorialList */
         Integer page = 1;
         int size = 20;
@@ -206,7 +206,7 @@ public class MemorialServiceImplTest {
 
     @Test
     @DisplayName("추모관 게시글 리스트 조회")
-    public void 추모관_게시글_리스트_조회() throws Exception {
+    public void 추모관_게시글_리스트_조회() {
         /* getMemorialList */
 
         MemorialNextCursor nextCursor = new MemorialNextCursor(null, null);
@@ -244,7 +244,7 @@ public class MemorialServiceImplTest {
 
     @Test
     @DisplayName("추모관 게시글 상세 조회")
-    public void 추모관_게시글_상세_조회() throws Exception {
+    public void 추모관_게시글_상세_조회() {
         /* getMemorialByDonateSeq */
 
         Integer donateSeq = 1;


### PR DESCRIPTION
## 📌 PR 제목
- 간단 요약: feat: Heaven 팝업용 게시물 검색 조회 기능 추가

## 📝 변경사항
- [x] `HeavenMemorialResponse` DTO 신규 정의  
- [x] Remembrance 모듈 내 Heaven 전용 검색 쿼리 추가  
- [x] `startDate`, `endDate`, `keyWord`, `page`, `size` 기반 검색 처리  
- [x] `letterCount`, `commentCount` 제외한 간소화 결과 반환  
- [x] 응답 정렬: 기증일 순 내림차순

## 🙋 기타 코멘트
