### PR TITLE
refactor: ActionLog 컬럼 타입 확장 및 HikariCP 설정 조정, Spring 로그 필터링 추가

### DIFF
--- a/src/main/java/kodanect/domain/logging/entity/ActionLog.java
+++ b/src/main/java/kodanect/domain/logging/entity/ActionLog.java
@@ -49,7 +49,7 @@ public class ActionLog {
     /**
      * 로그 내용
      */
-    @Column(name = "log_text", length = 3000)
+    @Column(name = "log_text", columnDefinition = "TEXT")
     private String logText;
 
     /**

--- a/src/main/java/kodanect/domain/logging/flusher/ActionLogFlusher.java
+++ b/src/main/java/kodanect/domain/logging/flusher/ActionLogFlusher.java
@@ -30,8 +30,6 @@ import java.util.*;
 @RequiredArgsConstructor
 public class ActionLogFlusher {
 
-    private static final int MAX_LOG_TEXT_LENGTH = 3000;
-
     private final FrontendLogBuffer frontendBuffer;
     private final BackendLogBuffer backendBuffer;
     private final SystemInfoBuffer systemInfoBuffer;
@@ -101,10 +99,6 @@ public class ActionLogFlusher {
 
             try {
                 String logText = objectMapper.writeValueAsString(context);
-
-                if (logText.length() > MAX_LOG_TEXT_LENGTH) {
-                    logText = logText.substring(0, MAX_LOG_TEXT_LENGTH);
-                }
 
                 String urlName = extractUrlName(feList, beList);
                 String ipAddr = MdcContext.getIpAddress();

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -22,7 +22,7 @@ spring.datasource.hikari.connection-timeout=5000
 spring.datasource.hikari.idle-timeout=30000
 spring.datasource.hikari.max-lifetime=300000
 
-spring.datasource.hikari.leak-detection-threshold=5000
+spring.datasource.hikari.leak-detection-threshold=10000
 
 # File storage path (production)
 globals.fileStorePath=/app/files

--- a/src/main/resources/log4j2-dev.xml
+++ b/src/main/resources/log4j2-dev.xml
@@ -26,6 +26,16 @@
             <AppenderRef ref="console"/>
         </Logger>
 
+        <!-- Spring Bean 생성 관련 Support 클래스 로그 (불필요한 DEBUG 로그 억제) -->
+        <Logger name="org.springframework.beans.factory.support" level="ERROR" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
+        <!-- Bean 후처리기 등록 시 발생하는 불필요한 Spring DEBUG 로그 억제 -->
+        <Logger name="org.springframework.context.support.PostProcessorRegistrationDelegate" level="ERROR" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
         <!-- SQL 실행 시간 측정 로그 -->
         <Logger name="jdbc.sqltiming" level="DEBUG" additivity="false">
             <AppenderRef ref="console"/>

--- a/src/main/resources/log4j2-prod.xml
+++ b/src/main/resources/log4j2-prod.xml
@@ -32,6 +32,16 @@
             <AppenderRef ref="console"/>
         </Logger>
 
+        <!-- Spring Bean 생성 관련 Support 클래스 로그 (불필요한 DEBUG 로그 억제) -->
+        <Logger name="org.springframework.beans.factory.support" level="ERROR" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
+        <!-- Bean 후처리기 등록 시 발생하는 불필요한 Spring DEBUG 로그 억제 -->
+        <Logger name="org.springframework.context.support.PostProcessorRegistrationDelegate" level="ERROR" additivity="false">
+            <AppenderRef ref="console"/>
+        </Logger>
+
         <Root level="INFO">
             <AppenderRef ref="console"/>
         </Root>


### PR DESCRIPTION
## 📌 PR 제목
refactor: ActionLog 컬럼 타입 확장 및 HikariCP 설정 조정, Spring 로그 필터링 추가

## 📝 변경사항
- [x] ActionLog.log_text 컬럼 타입을 VARCHAR(3000) → TEXT로 변경
- [x] ActionLogFlusher에서 logText 자르던 로직 제거 → 전체 로그 저장 가능
- [x] spring.datasource.hikari.leak-detection-threshold 값을 5000 → 10000(ms)로 조정
- [x] application-dev.properties, application-prod.properties에 Spring DEBUG 로그 억제 Logger 설정 추가

## 🙋 기타 코멘트